### PR TITLE
feat: add anchorID to refer to docs title.

### DIFF
--- a/meta.config.ts
+++ b/meta.config.ts
@@ -8,6 +8,7 @@ export type MirrorMeta = {
   forceShown?: boolean;
   link?: string;
   helpID?: string;
+  anchorID?: string;
   supportCli?: boolean;
   cliID?: string;
 };

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -216,6 +216,7 @@ function MirrorHelp({ item, mirrorMeta: mirrors, docsMeta: docs }: MirrorHelpPro
   const m = mirrors.find(u => u.id == item.name);
   const isGit = (m && m.type) ? m.type == 'git' : item.name.endsWith(".git");
   const helpid = (m && m.helpID) ? m.helpID : item.name;
+  const anchor = m?.anchorID ? '#' + m.anchorID : '';
 
   const [copied, setCopied] = useState(false);
   const ctx = React.useContext(SharedContext);
@@ -249,7 +250,7 @@ function MirrorHelp({ item, mirrorMeta: mirrors, docsMeta: docs }: MirrorHelpPro
       </span>
     }
     {docs.find(v => v.id == helpid) &&
-      <Link className={styles['help-link']} to={`/docs/${helpid}`} title={translate({
+      <Link className={styles['help-link']} to={`/docs/${helpid}${anchor}`} title={translate({
         id: 'mirror.table.help',
         message: '帮助文档'
       })} >


### PR DESCRIPTION
计划将子软件源（如 debian-security 和 debian-nonfree）的文档合并至主文档之中，并在镜像站主页保留链至对应子标题的帮助文档链接，因此需要在 `MirrorMeta` 中添加 `anchorID` 属性，并合成为文档链接完成定位。