### PR TITLE
Disable the switch of ubuntu security source

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -19,7 +19,7 @@ Ubuntu 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说�
 **为避免软件源配置文件替换后产生问题，请先将系统自带的软件源配置文件进行备份，然后进行下列操作。**
 :::
 
-1. 根据个人喜欢做出选择，并将如下软件源配置内容拷贝至 `/etc/apt/sources.list`，并进行保存。
+1. 根据个人情况对下列选项进行调整，并使用如下软件源配置替换 `/etc/apt/sources.list` 的原有内容：
 
 ```bash varcode
 [ ] (version) { jammy:22.04 LTS, lunar:23.04, kinetic:22.10, focal:20.04 LTS, bionic:18.04 LTS, xenial:16.04 LTS, trusty:14.04 LTS } Ubuntu 版本

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -12,10 +12,6 @@ Ubuntu 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说�
 ## Ubuntu 软件源替换
 
 :::caution
-**为了及时地获得安全更新，防止因软件源更新而导致的安全补丁滞后问题，我们推荐直接使用官方安全更新软件源。**
-:::
-
-:::caution
 **为避免软件源配置文件替换后产生问题，请先将系统自带的软件源配置文件进行备份，然后进行下列操作。**
 :::
 
@@ -70,14 +66,36 @@ ${SUDO}sed -i.bak 's|http://archive.ubuntu.com|${_http}://${_domain}|g' /etc/apt
 ${SUDO}apt update
 ```
 
-<!-- 本方法没有替换 security 源，如果想要替换 security 源可以执行以下命令：
+## Ubuntu Security 源
+
+:::caution
+**为了及时地获得安全更新，防止因软件源更新而导致的安全补丁滞后问题，我们推荐直接使用官方安全更新软件源。**
+:::
+
+因镜像站同步有延迟，可能会导致生产环境系统不能及时检查、安装最新的安全更新，因此不建议替换 security 源。
+
+如果存在官方源下载速度不理想等问题，可使用如下命令替换安全更新软件源：
+
 ```shell varcode
 [ ] (root) 是否为 root 用户
 ---
 const SUDO = !root ? 'sudo ' : '';
 ---
-${SUDO}sed -i.bak 's/security.ubuntu.com/${_domain}/g' /etc/apt/sources.list
-``` -->
+${SUDO}sed -i.bak 's|http://security.ubuntu.com|${_http}://${_domain}|g' /etc/apt/sources.list
+${SUDO}apt update
+```
+
+或将 security 源替换为以下内容：
+
+```shell varcode
+[ ] (version) { jammy:22.04 LTS, lunar:23.04, kinetic:22.10, focal:20.04 LTS, bionic:18.04 LTS, xenial:16.04 LTS, trusty:14.04 LTS } Ubuntu 版本
+[ ] (src) 启用源码镜像
+---
+const SRC_PREFIX = src ? "" : "# ";
+---
+deb ${_http}://${_domain}/ubuntu ${version}-security main restricted universe multiverse
+${SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu ${version}-security main restricted universe multiverse
+```
 
 ## 注意事项
 

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -99,9 +99,22 @@ ${SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu ${version}-security main restr
 
 ## 注意事项
 
-- 软件包架构说明
+### 软件包架构说明
 
 本镜像仅包含 x86 与 x64 架构处理器的软件包，在 ARM(arm64, armhf)、PowerPC(ppc64el)、RISC-V(riscv64) 以及 s390x 等架构的设备上，请使用 ubuntu-ports 镜像。
+
+### 关于 HTTPS 源
+
+如果遇到无法拉取 HTTPS 源的情况（如 docker 镜像中），请先使用 HTTP 源安装如下软件再进行换源。
+
+```shell varcode
+[ ] (root) 是否为 root 用户
+---
+const SUDO = !root ? 'sudo ' : '';
+---
+${SUDO}apt install apt-transport-https ca-certificates
+${SUDO}apt update
+```
 
 ## 引用
 

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -25,12 +25,9 @@ Ubuntu 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说�
 [ ] (version) { jammy:22.04 LTS, lunar:23.04, kinetic:22.10, focal:20.04 LTS, bionic:18.04 LTS, xenial:16.04 LTS, trusty:14.04 LTS } Ubuntu 版本
 [ ] (proposed) 启用预发布软件源
 [ ] (src) 启用源码镜像
-[ ] (forceSecurity) 使用 security 镜像 (强烈不推荐)
 ---
 const SRC_PREFIX = src ? "" : "# ";
 const PROPOSED_PREFIX = proposed ? "" : "# ";
-const SECURITY_URL = !forceSecurity ? "http://security.ubuntu.com/ubuntu/" : `${_http}://${_domain}/ubuntu/`;
-
 ---
 deb ${_http}://${_domain}/ubuntu/ ${version} main restricted universe multiverse
 ${SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu/ ${version} main restricted universe multiverse
@@ -39,8 +36,8 @@ ${SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu/ ${version}-updates main restr
 deb ${_http}://${_domain}/ubuntu/ ${version}-backports main restricted universe multiverse
 ${SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu/ ${version}-backports main restricted universe multiverse
 
-deb ${SECURITY_URL} jammy-security main restricted universe multiverse
-${SRC_PREFIX}deb-src ${SECURITY_URL} jammy-security main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
+${SRC_PREFIX}deb-src http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
 
 ${PROPOSED_PREFIX}deb ${_http}://${_domain}/ubuntu/ ${version}-proposed main restricted universe multiverse
 ${PROPOSED_PREFIX || SRC_PREFIX}deb-src ${_http}://${_domain}/ubuntu/ ${version}-proposed main restricted universe multiverse


### PR DESCRIPTION
1. 将文档中提供的安全更新源固定为官方源，并删除了相关的按钮
2. 修改了关于”替换软件源“的说明，明确指出应替换掉原始文件而非比较模糊的”拷贝至“的说法