### PR TITLE
Fix incorrect sed command for debian security

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -66,7 +66,7 @@ ${SUDO}apt update
 ---
 const SUDO = !root ? 'sudo ' : '';
 ---
-${SUDO}sed -i.bak 's|http://deb.debian.org|${_http}://${_domain}|g' /etc/apt/sources.list
+${SUDO}sed -i.bak 's|https\\?://deb.debian.org|${_http}://${_domain}|g' /etc/apt/sources.list
 ${SUDO}apt update
 ```
 
@@ -87,7 +87,7 @@ ${SUDO}apt update
 ---
 const SUDO = !root ? 'sudo ' : '';
 ---
-${SUDO}sed -i.bak 's|https://security.debian.org|${_http}://${_domain}|g' /etc/apt/sources.list
+${SUDO}sed -i.bak 's|https\\?://security.debian.org|${_http}://${_domain}|g' /etc/apt/sources.list
 ${SUDO}apt update
 ```
 

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -62,7 +62,7 @@ ${SUDO}apt update
 ---
 const SUDO = !root ? 'sudo ' : '';
 ---
-${SUDO}sed -i.bak 's|http://archive.ubuntu.com|${_http}://${_domain}|g' /etc/apt/sources.list
+${SUDO}sed -i.bak 's|https\\?://archive.ubuntu.com|${_http}://${_domain}|g' /etc/apt/sources.list
 ${SUDO}apt update
 ```
 
@@ -81,7 +81,7 @@ ${SUDO}apt update
 ---
 const SUDO = !root ? 'sudo ' : '';
 ---
-${SUDO}sed -i.bak 's|http://security.ubuntu.com|${_http}://${_domain}|g' /etc/apt/sources.list
+${SUDO}sed -i.bak 's|https\\?://security.ubuntu.com|${_http}://${_domain}|g' /etc/apt/sources.list
 ${SUDO}apt update
 ```
 


### PR DESCRIPTION
Debian 的默认 security 源使用 http 镜像，现有的 sed 命令无法匹配默认配置