### PR TITLE
Adjust the docs of debian and deepin

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -16,7 +16,7 @@ Debian 使用软件包管理工具 APT 来管理 DEB 软件包。具体来说，
 **为避免软件源配置文件替换后产生问题，请先将系统自带的软件源配置文件进行备份，然后进行下列操作。**
 :::
 
-1. 根据个人情况对下列选项进行调整，并将生成的软件源配置替换 `/etc/apt/sources.list` 的原有内容，并进行保存。
+1. 根据个人情况对下列选项进行调整，并使用如下软件源配置替换 `/etc/apt/sources.list` 的原有内容：
 
 ```shell varcode
 [ ] (version) { bookworm:Debian 12, bullseye:Debian 11, buster:Debian 10, testing:Testing, sid:Unstable SID} Debian 版本
@@ -70,9 +70,7 @@ ${SUDO}sed -i.bak 's|https\\?://deb.debian.org|${_http}://${_domain}|g' /etc/apt
 ${SUDO}apt update
 ```
 
-<div id="security"></div>
-
-## Debian Security 源
+## Debian Security 源 {#security}
 
 :::caution
 **为了及时地获得安全更新，防止因软件源更新而导致的安全补丁滞后问题，我们推荐直接使用官方安全更新软件源。**
@@ -108,9 +106,7 @@ deb ${_http}://${_domain}/debian-security ${version}-security main contrib non-f
 ${SRC_PREFIX}deb-src ${_http}://${_domain}/debian-security ${version}-security main contrib non-free${NFW}
 ```
 
-<div id="cd"></div>
-
-## Debian CD 镜像
+## Debian CD 镜像 {#cd}
 
 光盘映像以普通文件的形式准确记录了一片光盘里的数据，这样就可以在互联网上进行传输。光盘烧录程序也可利用映像制作出真正的光盘。
 

--- a/docs/debian.md
+++ b/docs/debian.md
@@ -99,19 +99,10 @@ ${SUDO}mv /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/debian.
 
 ## Debian CD 镜像 {#cd}
 
-光盘映像以普通文件的形式准确记录了一片光盘里的数据，这样就可以在互联网上进行传输。光盘烧录程序也可利用映像制作出真正的光盘。
+Debian 官方提供两种安装镜像：网络安装镜像（文件名含有 `netinst`）及 Live CD 镜像（文件名含有 `live`）。
 
-Debian 社区使用术语 `CD 镜像` 作为描述一类文件的通用方式，很多甚至装不进普通的 CD！这个名字很古老了，但它一直存在。Debian 社区会定期构建不同种类的镜像：
-
-- Debian 安装镜像，它们有多种不同的大小。从可以快速下载的小 CD 尺寸镜像 netinst 到为 DVD、蓝光光盘、双层蓝光光盘等设计的大型完整镜像。
-- Debian Live 镜像。Live 系统被设计为可直接从 CD/DVD/USB 上运行，而无需安装。
-
-在大多数情况下，这些安装镜像和 Live 镜像都可以直接被写入 USB 闪存盘中，而不用实际涉及到 CD，参见此处。不要被 CD 镜像这个名字所迷惑！
-
-目前 Debian 最新稳定版是 Bookworm (12.5.0)，
-
-- [点此链接](/release/?release=Debian)，选择需要的版本和架构下载最新的 Debian 安装镜像。
-- [点此链接](/release/?release=Debian%20Live%20CD%20(amd64))，选择需要的版本和架构下载最新的 Debian Live 镜像。
+- [网络安装镜像（点此跳转至下载页面）](/release/?release=Debian)：网络安装镜像只包含安装基本系统所需的最少的软件，通常具有较小的体积，但是需要互联网连接以安装完整系统。
+- [Live CD 镜像（点此跳转至下载页面）](/release/?release=Debian%20Live%20CD%20(amd64))：Live CD 镜像可用于直接启动 Debian 系统，并在没有互联网连接时完成安装，但仅支持 amd64 架构。
 
 ## Debian Security 源 {#security}
 

--- a/docs/debian.md
+++ b/docs/debian.md
@@ -70,6 +70,49 @@ ${SUDO}sed -i.bak 's|https\\?://deb.debian.org|${_http}://${_domain}|g' /etc/apt
 ${SUDO}apt update
 ```
 
+## 注意事项
+
+### 关于 HTTPS 源
+
+Debian Buster 以上版本默认支持 HTTPS 源。如果遇到无法拉取 HTTPS 源的情况（如 docker 镜像中），请先使用 HTTP 源安装如下软件再进行换源。
+
+```shell varcode
+[ ] (root) 是否为 root 用户
+---
+const SUDO = !root ? 'sudo ' : '';
+---
+${SUDO}apt install apt-transport-https ca-certificates
+${SUDO}apt update
+```
+
+### 关于 Debian Docker 镜像
+
+目前，最新版的 Debian Docker（Debian 12，bookworm）镜像将默认 apt 配置文件置于 `/etc/apt/sources.list.d` 目录中。手动替换软件源时，请使用以下指令使原配置文件无效化并备份：
+
+```shell varcode
+[ ] (root) 是否为 root 用户
+---
+const SUDO = !root ? 'sudo ' : '';
+---
+${SUDO}mv /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/debian.sources.bak
+```
+
+## Debian CD 镜像 {#cd}
+
+光盘映像以普通文件的形式准确记录了一片光盘里的数据，这样就可以在互联网上进行传输。光盘烧录程序也可利用映像制作出真正的光盘。
+
+Debian 社区使用术语 `CD 镜像` 作为描述一类文件的通用方式，很多甚至装不进普通的 CD！这个名字很古老了，但它一直存在。Debian 社区会定期构建不同种类的镜像：
+
+- Debian 安装镜像，它们有多种不同的大小。从可以快速下载的小 CD 尺寸镜像 netinst 到为 DVD、蓝光光盘、双层蓝光光盘等设计的大型完整镜像。
+- Debian Live 镜像。Live 系统被设计为可直接从 CD/DVD/USB 上运行，而无需安装。
+
+在大多数情况下，这些安装镜像和 Live 镜像都可以直接被写入 USB 闪存盘中，而不用实际涉及到 CD，参见此处。不要被 CD 镜像这个名字所迷惑！
+
+目前 Debian 最新稳定版是 Bookworm (12.5.0)，
+
+- [点此链接](/release/?release=Debian)，选择需要的版本和架构下载最新的 Debian 安装镜像。
+- [点此链接](/release/?release=Debian%20Live%20CD%20(amd64))，选择需要的版本和架构下载最新的 Debian Live 镜像。
+
 ## Debian Security 源 {#security}
 
 :::caution
@@ -104,49 +147,6 @@ const SRC_PREFIX = src ? "" : "# ";
 ---
 deb ${_http}://${_domain}/debian-security ${version}-security main contrib non-free${NFW}
 ${SRC_PREFIX}deb-src ${_http}://${_domain}/debian-security ${version}-security main contrib non-free${NFW}
-```
-
-## Debian CD 镜像 {#cd}
-
-光盘映像以普通文件的形式准确记录了一片光盘里的数据，这样就可以在互联网上进行传输。光盘烧录程序也可利用映像制作出真正的光盘。
-
-Debian 社区使用术语 `CD 镜像` 作为描述一类文件的通用方式，很多甚至装不进普通的 CD！这个名字很古老了，但它一直存在。Debian 社区会定期构建不同种类的镜像：
-
-- Debian 安装镜像，它们有多种不同的大小。从可以快速下载的小 CD 尺寸镜像 netinst 到为 DVD、蓝光光盘、双层蓝光光盘等设计的大型完整镜像。
-- Debian Live 镜像。Live 系统被设计为可直接从 CD/DVD/USB 上运行，而无需安装。
-
-在大多数情况下，这些安装镜像和 Live 镜像都可以直接被写入 USB 闪存盘中，而不用实际涉及到 CD，参见此处。不要被 CD 镜像这个名字所迷惑！
-
-目前 Debian 最新稳定版是 Bookworm (12.5.0)，
-
-- [点此链接](/release/?release=Debian)，选择需要的版本和架构下载最新的 Debian 安装镜像。
-- [点此链接](/release/?release=Debian%20Live%20CD%20(amd64))，选择需要的版本和架构下载最新的 Debian Live 镜像。
-
-## 注意事项
-
-### 关于 HTTPS 源
-
-Debian Buster 以上版本默认支持 HTTPS 源。如果遇到无法拉取 HTTPS 源的情况（如 docker 镜像中），请先使用 HTTP 源安装如下软件再进行换源。
-
-```shell varcode
-[ ] (root) 是否为 root 用户
----
-const SUDO = !root ? 'sudo ' : '';
----
-${SUDO}apt install apt-transport-https ca-certificates
-${SUDO}apt update
-```
-
-### 关于 Debian Docker 镜像
-
-目前，最新版的 Debian Docker（Debian 12，bookworm）镜像将默认 apt 配置文件置于 `/etc/apt/sources.list.d` 目录中。手动替换软件源时，请使用以下指令使原配置文件无效化并备份：
-
-```shell varcode
-[ ] (root) 是否为 root 用户
----
-const SUDO = !root ? 'sudo ' : '';
----
-${SUDO}mv /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/debian.sources.bak
 ```
 
 ## 引用

--- a/docs/deepin.md
+++ b/docs/deepin.md
@@ -6,9 +6,9 @@ cname: 'deepin'
 
 ## Deepin 简介与软件管理
 
-Deepin (原名 Linux Deepin) 致力于为全球用户提供美观易用，安全可靠的 Linux 发行版。Deepin 项目于 2008 年发起，并在 2009 年发布了以 linux deepin 为名称的第一个版本。2014 年 4 月更名为 deepin，在中国常被称为“深度操作系统“。Deepin 是一款基于 Linux 内核,以桌面系统为主的开源操作系统。它拥有简洁现代的界面,丰富的应用软件和工具,能满足日常的办公、学习和娱乐需求。
+Deepin (原名 Linux Deepin) 致力于为全球用户提供美观易用，安全可靠的 Linux 发行版。Deepin 项目于 2008 年发起，并在 2009 年发布了以 linux deepin 为名称的第一个版本。2014 年 4 月更名为 deepin，在中国常被称为“深度操作系统“。Deepin 是一款基于 Linux 内核，以桌面系统为主的开源操作系统。它拥有简洁现代的界面，丰富的应用软件和工具，能满足日常的办公、学习和娱乐需求。
 
-Deepin 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说，deepin 通过修改 `/etc/apt/sources.list` 配置文件来管理系统软件源。一般情况下，用户可直接将该配置文件中的默认源地址 <https://community-packages.deepin.com/`> 替换为本软件镜像站。
+Deepin 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说，deepin 通过修改 `/etc/apt/sources.list` 配置文件来管理系统软件源。一般情况下，用户可直接将该配置文件中的默认源地址 <https://community-packages.deepin.com/> 替换为本软件镜像站。
 
 ## Deepin 软件源替换
 
@@ -16,13 +16,12 @@ Deepin 使用软件包管理工具 `APT` 来管理 DEB 软件包。具体来说�
 **为避免软件源配置文件替换后产生问题，请先将系统自带的软件源配置文件进行备份，然后进行下列操作。**
 :::
 
-1. 根据个人喜欢做出选择，并将如下软件源配置内容拷贝至 `/etc/apt/sources.list`，并进行保存。
+1. 根据个人情况对下列选项进行调整，并使用如下软件源配置替换 `/etc/apt/sources.list` 的原有内容：
 
 ```shell varcode
-[ ] (root) 是否为 root 用户
-[ ] (version) { apricot:Deepin 20, beige:Deepin 23 } Deepin 版本
+[ ] (version) { apricot:Deepin 20, beige:Deepin 23（不支持 Nightly） } Deepin 版本
+[ ] (src) 启用源码镜像
 ---
-const SUDO = !root ? 'sudo ' : '';
 let COMMAND = '';
 
 if (version == 'apricot') {
@@ -31,8 +30,10 @@ if (version == 'apricot') {
 if (version == 'beige') {
   COMMAND = `://${_domain}/deepin/beige beige main community commercial`;
 }
+const SRC_PREFIX = src ? "" : "# ";
 ---
 deb ${_http}${COMMAND}
+${SRC_PREFIX}deb-src ${_http}${COMMAND}
 ```
 
 2. 通过如下命令更新软件。
@@ -55,7 +56,7 @@ ${SUDO}apt update
 
 ```shell varcode
 [ ] (root) 是否为 root 用户
-[ ] (version) { apricot:Deepin 20, beige:Deepin 23 } Deepin 版本
+[ ] (version) { apricot:Deepin 20, beige:Deepin 23（不支持 Nightly） } Deepin 版本
 ---
 const SUDO = !root ? 'sudo ' : '';
 let COMMAND = '';
@@ -71,12 +72,14 @@ if (version == 'beige') {
   STR_REPLACED = `${_domain}/deepin/` + version;
 }
 ---
-${SUDO}sed -E -e "s|https?://${STR_TO_REPLACE}|${_http}://${STR_REPLACED}|" /etc/apt/sources.list
+${SUDO}sed -i.bak -E -e "s|https?://${STR_TO_REPLACE}|${_http}://${STR_REPLACED}|" /etc/apt/sources.list
 ```
 
 ## 注意事项
 
 - 本镜像站不同步 Deepin 20 前的版本，如有需要请使用官方源。
+
+- 本镜像站不同步 Deepin 23 Nightly 版本，如有需要请使用官方源。
 
 - 本镜像站不提供 Deepin App Store 的镜像，因此请不要修改 `/etc/apt/sources.list` 中与 App Store 有关的源，如 <https://app-store-files.uniontech.com/>
 

--- a/docs/deepin.md
+++ b/docs/deepin.md
@@ -93,3 +93,11 @@ const SUDO = !root ? 'sudo ' : '';
 ${SUDO}apt install apt-transport-https ca-certificates
 ${SUDO}apt update
 ```
+
+## Deepin 安装镜像 {#cd}
+
+本站提供 amd64 架构的 Deepin 安装镜像下载，[点击链接跳转](/release?release=deepin)。
+
+:::info
+本站收录了 Deepin 23 Nightly 的安装镜像，但暂不提供其软件源镜像，如有需要请使用官方源。
+:::

--- a/meta.config.ts
+++ b/meta.config.ts
@@ -67,7 +67,7 @@ const mirrors: MirrorMeta[] = [
   { id: 'CRAN', description: 'R语言的可执行文件、源代码和说明文件' },
   { id: 'crates', description: '面向Rust语言的软件包仓库文件', supportCli: true },
   { id: 'crates.io-index', description: '面向Rust语言的软件包索引列表，支持git索引和稀疏索引', helpID: 'crates', supportCli: true, cliID: 'crates' },
-  { id: 'deepin-cd', description: 'Deepin 镜像文件' },
+  { id: 'deepin-cd', description: 'Deepin 镜像文件', helpID: 'deepin', anchorID: 'cd' },
   { id: 'gnu', description: 'GNU软件的源码包和文档仓库' },
   { id: 'golang', description: 'Go语言工具链' },
   { id: 'openkylin-cdimage', description: 'openKylin 镜像文件' },


### PR DESCRIPTION
## Debian

1. 使用 docusaurus 支持的 extended markdown 语法设置标题的 id，不再使用空的 div 标签。
2. 将 cd 和 security 的文档移至注意事项之后（来自 @jingfelix 的建议，这两部分文档与 debian 主体关联性较小，移动位置可保持把最重要的信息放在最前面）
3. debian cd 文档中存在类似“点击此处”的描述却没有超链接，因此调整优化了 debian cd 文档。

## Deepin

1. 规范化文档
2. 修复 sed 指令不真正替换文件内容的 bug
3. 删除多余的“是否为 root 用户”的选项
4. 增加 src 源的配置
5. 注明我们不支持 deepin 23 nighly 的软件镜像
6. 增添了 cd 文档