### PR TITLE
add ubuntu-release doc in ubuntu.md

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -66,6 +66,14 @@ ${SUDO}sed -i.bak 's|https\\?://archive.ubuntu.com|${_http}://${_domain}|g' /etc
 ${SUDO}apt update
 ```
 
+## Ubuntu Release 镜像 {#cd}
+Ubuntu 官方提供两种安装镜像：桌面版安装镜像及服务器版安装镜像。
+
+- 桌面版安装镜像是专为桌面 PC 和笔记本打造的 Ubuntu 版本，其可以让你在不安装系统的前提下尝试 Ubuntu 系统，请注意要安装桌面版系统至少需要 384 MiB 的 RAM 大小。
+- 服务器版安装镜像将安装一个不带用户图形界面纯命令行的 Ubuntu 系统，通常用于部署服务器。
+
+要下载这两个版本的安装镜像，请前往[下载页面](/release/?release=Ubuntu)选择对应的版本和种类进行下载。
+
 ## Ubuntu Security 源
 
 :::caution

--- a/meta.config.ts
+++ b/meta.config.ts
@@ -47,7 +47,7 @@ const mirrors: MirrorMeta[] = [
   { id: 'deepin', type: 'normal', description: 'Deepin 软件仓库', helpID: 'deepin', supportCli: true },
   { id: 'openeuler', type: 'normal', description: 'OpenEuler 软件仓库', helpID: 'openeuler', supportCli: true },
   { id: 'openkylin', type: 'normal', description: 'OpenKylin 软件仓库', helpID: 'openkylin', supportCli: true },
-  { id: 'ubuntu', type: 'normal', description: 'Ubuntu 软件仓库', helpID: 'ubuntu', supportCli: true },
+  { id: 'ubuntu', type: 'normal', description: 'Ubuntu 软件仓库', helpID: 'ubuntu', supportCli: true, anchorID: 'cd' },
   { id: 'anolis', description: '阿里龙蜥软件仓库', supportCli: true },
   { id: 'AOSP', description: 'Android 源代码仓库' },
   { id: 'debian-cd', description: 'Debian GNU/Linux 最新版镜像仓库', helpID: 'debian', anchorID: 'cd'},


### PR DESCRIPTION
add ubuntu-release doc in ubuntu.md. It can be accessed by `https://mirrors.hust.edu.cn/docs/ubuntu#cd`. Ref to [#29 ](https://github.com/hust-open-atom-club/hust-mirrors/issues/29)