### PR TITLE
chore: fix the incorrect linux-stable link

### DIFF
--- a/meta.config.ts
+++ b/meta.config.ts
@@ -39,7 +39,7 @@ export type ReleaseMeta = {
 
 const mirrors: MirrorMeta[] = [
   { id: 'linux.git', type: 'git', description: 'Linux 内核主线仓库', helpID: 'linux.git' },
-  { id: 'linux-stable.git', type: 'git', description: 'Linux 内核稳定分支仓库', helpID: 'linux.git' },
+  { id: 'linux-stable.git', type: 'git', description: 'Linux 内核稳定分支仓库', helpID: 'linux-stable.git' },
   { id: 'linux-next.git', type: 'git', description: 'Linux 内核源开发分支仓库', helpID: 'linux-next.git' },
   { id: 'qemu.git', type: 'git', description: '处理器模拟器 QEMU 代码仓库' },
   { id: 'archlinux', type: 'normal', description: 'Arch Linux 软件仓库', helpID: 'archlinux', supportCli: true },


### PR DESCRIPTION
`linux-stable.git`的文档链接错误指向`linux.git`，修改为正确的链接。