### PR TITLE
docs: Unified English docs title format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build project
+        run: yarn build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,8 +19,10 @@ jobs:
       - name: Lint Markdown files
         run: |
           mkdir -p linted_output
-          for file in $(find . -name '*.md'); do
-            zhlint "$file" --output="linted_output/$(basename "$file")"
+          find . -name '*.md' | while read file; do
+            output_dir="linted_output/$(dirname "$file")"
+            mkdir -p "$output_dir"
+            zhlint "$file" --output="$output_dir/$(basename "$file")"
           done
 
       - name: Upload Linted Markdown

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,19 @@ jobs:
       - name: Lint Markdown files
         run: |
           mkdir -p linted_output
+          lint_failed=0
           find . -name '*.md' | while read file; do
             output_dir="linted_output/$(dirname "$file")"
             mkdir -p "$output_dir"
             zhlint "$file" --output="$output_dir/$(basename "$file")"
+            if [ $? -ne 0 ]; then
+              echo "Linting failed for $file"
+              lint_failed=1
+            fi
           done
+          if [ $lint_failed -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Upload Linted Markdown
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install zhlint
         run: yarn global add zhlint
@@ -24,7 +24,7 @@ jobs:
           done
 
       - name: Upload Linted Markdown
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: linted-markdown
           path: linted_output/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install zhlint
+        run: yarn global add zhlint
+
+      - name: Lint Markdown files
+        run: |
+          mkdir -p linted_output
+          for file in $(find . -name '*.md'); do
+            zhlint "$file" --output="linted_output/$(basename "$file")"
+          done
+
+      - name: Upload Linted Markdown
+        uses: actions/upload-artifact@v2
+        with:
+          name: linted-markdown
+          path: linted_output/

--- a/i18n/en/docusaurus-plugin-content-docs/current/linux-next.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux-next.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux-next.git
+title: Linux Next Git
 sidebar_label: Linux Next
 cname: 'linux-next.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linux-stable.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux-stable.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux-stable.git
+title: Linux Stable Git
 sidebar_label: Linux Stable
 cname: 'linux-stable.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linux.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux.git
+title: Linux Mainline Git
 sidebar_label: Linux Mainline
 cname: 'linux.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linuxmint.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linuxmint.md
@@ -1,5 +1,5 @@
 ---
-title: Linux Mint Usage Guide
+title: Linux Mint
 sidebar_label: Linux Mint
 cname: LinuxMint
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/qemu.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/qemu.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use QEMU mirror
+title: QEMU Git
 cname: 'qemu.git'
 sidebar_label: QEMU
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/termux.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/termux.md
@@ -1,5 +1,5 @@
 ---
-title: Termux Software repository mirror usage help
+title: Termux
 sidebar_label: Termux
 cname: termux
 ---


### PR DESCRIPTION
All English documentation titles are converted to the format of bare mirror name. 

For example, `How to use linux-next.git` will be formatted into `Linux Next Git`