### PR TITLE
docs: Unified English docs title format

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/linux-next.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux-next.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux-next.git
+title: Linux Next Git
 sidebar_label: Linux Next
 cname: 'linux-next.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linux-stable.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux-stable.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux-stable.git
+title: Linux Stable Git
 sidebar_label: Linux Stable
 cname: 'linux-stable.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linux.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linux.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use linux.git
+title: Linux Mainline Git
 sidebar_label: Linux Mainline
 cname: 'linux.git'
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/linuxmint.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/linuxmint.md
@@ -1,5 +1,5 @@
 ---
-title: Linux Mint Usage Guide
+title: Linux Mint
 sidebar_label: Linux Mint
 cname: LinuxMint
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/qemu.git.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/qemu.git.md
@@ -1,5 +1,5 @@
 ---
-title: How to use QEMU mirror
+title: QEMU Git
 cname: 'qemu.git'
 sidebar_label: QEMU
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/termux.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/termux.md
@@ -1,5 +1,5 @@
 ---
-title: Termux Software repository mirror usage help
+title: Termux
 sidebar_label: Termux
 cname: termux
 ---


### PR DESCRIPTION
All English documentation titles are converted to the format of bare mirror name. 

For example, `How to use linux-next.git` will be formatted into `Linux Next Git`