### PR TITLE
feat(ci): add workflows of website build and markdown lint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build project
+        run: yarn build

--- a/.github/workflows/lint-all.yaml
+++ b/.github/workflows/lint-all.yaml
@@ -1,9 +1,7 @@
-name: Lint
+name: Lint All
 
 on:
-  pull_request:
-    paths:
-      - '**/*.md'
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -15,24 +13,17 @@ jobs:
       - name: Install zhlint
         run: yarn global add zhlint
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          files: '**/*.md'
-
-      - name: Lint Markdown files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      - name: Lint all Markdown files
         run: |
           mkdir -p linted_output
           file_list="linted_output/file_list.txt"
-          linted_failed=0
-          for file in ${{ env.ALL_CHANGED_FILES }}; do
+          linted_failed_file=$(mktemp)
+          echo 0 > "$linted_failed_file"
+          find . -type f -name '*.md' | while read -r file; do
             set +e
             zhlint "$file"
             if [ $? -ne 0 ]; then
-              linted_failed=1
+              echo 1 > "$linted_failed_file"
               echo "$file" >> "$file_list"
               output_file="linted_output/report_and_suggested_fixes/$file"
               mkdir -p "$(dirname "$output_file")"
@@ -40,9 +31,11 @@ jobs:
             fi
             set -e
           done
+          linted_failed=$(cat "$linted_failed_file")
+          rm "$linted_failed_file"
           echo "linted_failed=$linted_failed" >> "$GITHUB_ENV"
 
-      - name: Upload Linted Markdown
+      - name: Upload linted Markdown
         uses: actions/upload-artifact@v4
         with:
           name: linted-markdown

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install zhlint
+        run: yarn global add zhlint
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+      - name: Lint Markdown files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          mkdir -p linted_output
+          for file in ${{ env.ALL_CHANGED_FILES }}; do
+            output_dir="linted_output/$(dirname "$file")"
+            mkdir -p "$output_dir"
+            zhlint "$file" --output="$output_dir/$(basename "$file")"
+          done
+
+      - name: Upload Linted Markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: linted-markdown
+          path: linted_output/
+
+      - name: Check lint errors
+        run: |
+          if [ -n "$(ls -A linted_output)" ]; then
+            echo "Linting errors found. Please check the uploaded artifacts and the lint logs."
+            exit 1
+          fi


### PR DESCRIPTION
Added three workflows regarding #70 :

- `build`: Check website build, triggered by pull requests
- `lint`: Triggered by pull requests with md files, lint the changed md files with `zhlint`, generating an artifact with `zhlint` log and autofix files
- `lint-all`: Same function as `lint`, but triggered manually, checking all the md files in the repo

Test PRs & workflows:
- Lint success PR: inscripoem/hust-mirrors#8
- Lint failed PR: inscripoem/hust-mirrors#9
- [Lint all test run](https://github.com/inscripoem/hust-mirrors/actions/runs/11796540323)