### PR TITLE
fix: undefined help id on cli advertisement

### DIFF
--- a/src/components/CliAdvertisement/index.tsx
+++ b/src/components/CliAdvertisement/index.tsx
@@ -8,6 +8,9 @@ import React from 'react'
 export default function () {
   const { pathname } = useLocation();
   const mirrorHelpid = pathname.split('/')[2];
+  if (!mirrorHelpid) {
+    return null;
+  }
   const metas = useMirrorMetas();
   let ok = false;
   const meta = metas.find(u => u.id == mirrorHelpid || u.helpID == mirrorHelpid);

--- a/src/components/CliAdvertisement/index.tsx
+++ b/src/components/CliAdvertisement/index.tsx
@@ -7,7 +7,12 @@ import React from 'react'
 
 export default function () {
   const { pathname } = useLocation();
-  const mirrorHelpid = pathname.split('/')[2];
+  const pathSegments = pathname.split('/').filter(Boolean);
+  const docsSegmentIndex = pathSegments.indexOf('docs');
+  const mirrorHelpid =
+    docsSegmentIndex >= 0 && docsSegmentIndex + 1 < pathSegments.length
+      ? pathSegments[docsSegmentIndex + 1]
+      : undefined;
   if (!mirrorHelpid) {
     return null;
   }

--- a/src/components/CliAdvertisement/index.tsx
+++ b/src/components/CliAdvertisement/index.tsx
@@ -9,6 +9,7 @@ export default function () {
   const { pathname } = useLocation();
   const pathSegments = pathname.split('/').filter(Boolean);
   const docsSegmentIndex = pathSegments.indexOf('docs');
+  const maybeLanguage = pathSegments[0];
   const mirrorHelpid =
     docsSegmentIndex >= 0 && docsSegmentIndex + 1 < pathSegments.length
       ? pathSegments[docsSegmentIndex + 1]
@@ -22,10 +23,12 @@ export default function () {
   if (meta && meta.supportCli) {
     ok = true;
   }
-  return ok && (<Admonition type='tip' icon='🌈' title={mirrorHelpid + translate({
-    id: 'mirror.supportCli.title',
-    message: '支持CLI部署'
-  })}>
+  return ok && (<Admonition type='tip' icon='🌈' title={
+    mirrorHelpid + (maybeLanguage === 'en' ? ' ' : '') + translate({
+      id: 'mirror.supportCli.title',
+      message: '支持CLI部署'
+    })
+  }>
     <Translate id='mirror.supportCli'>
       该程序包支持命令行工具一键部署，
     </Translate>


### PR DESCRIPTION
Fixes #290

当 mirrorHelpid 值为空时直接跳过后续查找逻辑