### PR TITLE
docs(i18n): 补全 2026 年 4-8 月博客动态的英文翻译

### DIFF
--- a/i18n/en/docusaurus-plugin-content-blog/2026/04-04-change.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2026/04-04-change.md
@@ -1,0 +1,19 @@
+---
+title: Mirror Changes Notice - 2026.04.04
+authors: yeying-xingchen
+---
+
+To better meet user needs and optimize resource allocation, we have adjusted the synchronization policies of the mirror site as follows:
+
+1. Removed Mirrors:
+   - Removed synchronization for `gentoo-portage`
+   - Removed synchronization for `libnvidia-container.git`
+
+2. Upstream Changes:
+   - Changed upstream for `anthon`
+   - Changed upstream for `docker-ce`
+
+3. Sync Method Changes:
+   - Changed the synchronization method for `golang`. After the fix, Golang can sync the latest versions properly.
+
+We will continue to monitor the stability of our mirror services to provide a better user experience. Thank you for your continued support and understanding.

--- a/i18n/en/docusaurus-plugin-content-blog/2026/05-28-service-degrade.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2026/05-28-service-degrade.md
@@ -1,0 +1,15 @@
+---
+title: Apology Statement Regarding Mirror Service Disruption
+authors: paulkm
+---
+
+Dear mirror users,
+
+Between May 8 and May 27, 2026, due to unplanned adjustments to the campus network infrastructure, the availability and connection speeds of the mirror site were significantly impacted, resulting in frequent synchronization failures. Consequently, the maintenance team was unable to publish timely announcements to users. We deeply apologize for this service disruption and the delayed communication.
+
+Currently, the university's adjustments have been completed. The synchronization services for most major mirror sources have largely returned to normal, while a few mirrors are still catching up with their sync progress. We are also actively evaluating solutions to prevent similar incidents in the future.
+
+To facilitate timely status updates on the mirror site moving forward, you are welcome to join our maintenance QQ group: [Click to join the group "HUST Open Source Mirror Site Communication Group"](https://qm.qq.com/q/ybvQ0XZXkQ)
+
+HUST Open Source Mirror Site Maintenance Team  
+May 28, 2026

--- a/i18n/en/docusaurus-plugin-content-blog/2026/08-02-change.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2026/08-02-change.md
@@ -1,0 +1,25 @@
+---
+title: Mirror Changes Notice - 2026.08.02
+authors: paulkm
+---
+
+Dear mirror users,
+
+Due to the impending exhaustion of disk space on the mirror servers, and to better meet user demands while optimizing resource allocation, we have made the following adjustments to the mirror site:
+
+1. Sync Policy Adjustments:
+
+   Starting from August 2, 2026, the HUST Open Source Mirror Site **will no longer guarantee synchronization for EOL (End of Life) versions of distributions**. This includes package repositories and installation images corresponding to those versions.
+
+   Please note that the mirror site currently still retains some EOL files for certain distributions, but these files are very likely to be removed in future maintenance.
+
+   Moving forward, the mirror site will only guarantee the synchronization of files that are **still within the distribution's official support lifecycle (including LTS and security update support periods)**.
+
+   Currently, legacy version mirrors for the following distributions have been removed:
+   - Removed sync for `alpine` EOL versions (`v3.0` - `v3.20`)
+   - Removed sync for `openEuler` EOL versions (see [openEuler Official](https://www.openeuler.openatom.cn/en/other/lifecycle/))
+
+2. Removed Mirrors:
+   - Removed synchronization for `fdroid`. The `fdroid` repository occupied over 6TB of mirror disk space, but accumulated less than 200GB of traffic during the previous reporting period (January–June 2026). We have redirected requests under the `fdroid` path to the Tsinghua University TUNA mirror site.
+
+We will continue to monitor the stability of our mirror services to provide a higher quality user experience. Thank you for your continued support and understanding.

--- a/i18n/en/docusaurus-plugin-content-blog/2026/08-28-change.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2026/08-28-change.md
@@ -1,0 +1,21 @@
+---
+title: Mirror Changes Notice - 2026.08.28
+authors: paulkm
+---
+
+Dear mirror users,
+
+Due to recent poor connectivity between the mirror servers and GitHub, as well as the high CPU consumption caused by the `cgit` service, we have made the following adjustments to better meet user demands and optimize resource allocation:
+
+1. Sync Source Adjustments:
+
+   Starting from August 28, 2026, package releases under `github-releases` will be pulled via a Cloudflare reverse proxy mirror. For the vast majority of users, this change will not cause any noticeable impact. However, due to upstream synchronization policies, there is a cache duration for Release files, which may introduce a delay of several hours in syncing.
+
+2. Removed Mirrors:
+   - Removed synchronization for `llvm-project.git`. This path has been redirected to upstream GitHub.
+   - Removed synchronization for `metasploit-framework.git`. This path has been redirected to upstream GitHub.
+
+3. Added Mirrors:
+   - Added synchronization for [`github-release/hust-open-atom-club/oh-dsh`](https://mirrors.hust.edu.cn/github-release/hust-open-atom-club/oh-dsh/LatestRelease/). [Oh-DSH](https://dsh.openatom.club) is a DeepSeek Harness desktop distribution built and maintained by the HUST OpenAtom Club, featuring a rich set of built-in plugins, out-of-the-box readiness, and continuous updates. Everyone is welcome to use it, provide feedback, and submit Issues or Pull Requests to the [GitHub](https://github.com/hust-open-atom-club/oh-dsh) repository.
+
+We will continue to monitor the stability of our mirror services to provide a higher quality user experience. Thank you for your continued support and understanding.

--- a/i18n/en/docusaurus-plugin-content-blog/2026/08-28-mirrorz.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2026/08-28-mirrorz.md
@@ -1,0 +1,16 @@
+---
+title: Official Launch of CERNET Joint Mirrors
+authors: mirrorz
+---
+
+On August 22, 2026, the launch ceremony for the CERNET Joint Mirrors ([https://mirrors.cernet.edu.cn](https://mirrors.cernet.edu.cn)) was held during the 4th Open Source Software Forum hosted by the e-Science Center of Nanjing University. The project was initiated by the Tsinghua University Open Source Software Mirror Station in 2020, with the CERNET Network Center providing computing, domain name, and network resource support. To date, more than 27 domestic universities and research institutes have joined. The HUST Open Source Software Mirror Station joined the project in February 2026.
+
+The CERNET Joint Mirrors aims to integrate open source mirror resources from domestic universities and research institutions, providing education network users with more convenient and flexible open source software download services. Unlike traditional open source mirror sites, the joint mirror site does not host mirror contents directly. Instead, it aggregates mirror resources from member institutions through a unified entry point and dynamically schedules requests based on the user's network location and the availability status of each mirror node. Users do not need to manually select a mirror site; by simply configuring the unified domain name, they can access over a hundred mirror resources, including Linux distributions, programming language ecosystems, and other popular open source software. The joint mirror site also provides comprehensive documentation to help users query configurations and usage instructions for various mirror sources.
+
+As the demand for open source software in higher education continues to grow, the model of individual institutions independently building and maintaining mirror sites faces increasing challenges in terms of bandwidth, storage, maintenance, and cross-regional access. By fully leveraging CERNET network resources and the infrastructure of member institutions, the joint mirror site reduces redundant construction while improving the overall reliability and availability of open source software distribution services.
+
+For more details about the launch ceremony, please refer to the [relevant report](https://mp.weixin.qq.com/s/ipei4VrTTII0DgZqzMIzyw). You are welcome to try out the CERNET Joint Mirrors and provide feedback and suggestions for improvement.
+
+---
+
+Source: MirrorZ Project


### PR DESCRIPTION
### 完成情况 
- [x] 翻译并新增 2026 年 4 月至 8 月的 5 篇英文动态文章。
- [x] 已完整保留原有的 Front matter（日期、作者、标签等）及各项元数据。
- [x] 确保了所有项目名、镜像名及 URL 链接的准确性，未做修改。
- [x] 本地已顺利通过 `yarn build` 与 `yarn typecheck` 测试。