### PR TITLE
fix: exclude internal templates from sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,14 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        sitemap: {
+          ignorePatterns: [
+            '/cgit/**',
+            '/fancyindex/**',
+            '/**/cgit/**',
+            '/**/fancyindex/**',
+          ],
+        },
       }),
     ],
   ],

--- a/plugin/cgit/README.md
+++ b/plugin/cgit/README.md
@@ -1,6 +1,10 @@
-# Config Sample
+# cgit configuration sample
 
-```
+The cgit post-build plugin generates the head, header, and footer fragments used
+by the production cgit deployment. A minimal corresponding cgit configuration
+looks like this:
+
+```ini
 virtual-root=/git
 
 head-include=<HEAD_FILE_FS_PATH>


### PR DESCRIPTION
## Summary

- exclude the cgit and fancyindex template routes from both default and localized sitemaps
- move the cgit deployment sample out of `src/pages` so it no longer becomes a public route
- keep the cgit and fancyindex post-build inputs and generated integration resources unchanged

Fixes #317

## Validation

- `yarn test` (8 passed)
- targeted Docusaurus production build for both `zh-Hans` and `en`, using the normal page shell and post-build plugins while replacing the currently broken docs corpus with one inert validation page
- verified both generated `sitemap.xml` files contain no `cgit`, `fancyindex`, or `README` route
- verified both locales still generate cgit head/header/footer/JS/CSS and fancyindex header/footer/JS artifacts

## Existing baseline boundaries

- the unmodified full `yarn build` stops on existing MDX parse errors in `docs/crates.md`, `docs/deepin.md`, and `docs/rustup.md`
- the unmodified TypeScript baseline reports existing dependency/configuration errors, starting with TypeScript 4.7 rejecting the Docusaurus `moduleResolution` setting